### PR TITLE
feat: add ToSql / FromSql implementations for `chrono` and `time` date and time types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,6 +77,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
+name = "cc"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,10 +97,19 @@ version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
+ "windows-targets",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "darling"
@@ -119,7 +152,9 @@ version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf1bedf64cdb9643204a36dd15b19a6ce8e7aa7f7b105868e9f1fad5ffa7d12"
 dependencies = [
+ "chrono",
  "diesel_derives",
+ "time",
 ]
 
 [[package]]
@@ -139,10 +174,12 @@ name = "diesel-d1"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "diesel",
  "diesel-async",
  "futures-util",
  "js-sys",
+ "time",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "worker",
@@ -308,6 +345,29 @@ checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -520,6 +580,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,6 +747,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +820,24 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+dependencies = [
+ "itoa",
+ "libc",
+ "num_threads",
+ "time-macros",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "tinystr"
@@ -883,6 +976,15 @@ checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,22 @@ description = "A Diesel Backend/Connection for Cloudflare D1."
 
 [dependencies]
 async-trait = "0.1.83"
+chrono = { version = "0.4", optional = true, default-features = false }
 diesel = { version = "2.2.6", features = [
-    "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+  "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
 ] }
 diesel-async = "0.5.2"
 futures-util = "0.3.31"
 js-sys = "0.3.74"
+time = { version = "0.3.9", optional = true, features = [
+  "macros",
+  "formatting",
+  "parsing",
+] }
 wasm-bindgen = "0.2.97"
 wasm-bindgen-futures = "0.4.49"
-worker = { version = "0.4.2"}
+worker = { version = "0.4.2" }
+
+[features]
+chrono = ["dep:chrono", "diesel/chrono"]
+time = ["dep:time", "diesel/time"]

--- a/src/types/date_and_time/chrono.rs
+++ b/src/types/date_and_time/chrono.rs
@@ -1,0 +1,131 @@
+// Since D1 is a SQlite-compatible DB, we have borrowed time/date/timestamp
+// formats, conversion functions and base impls of the FromSql/ToSql traits
+// from the upstream diesel::sqlite::types::date_and_time::chrono module
+
+extern crate chrono;
+
+use diesel::{
+    deserialize::{self, FromSql},
+    serialize::{self, IsNull, Output, ToSql},
+    sql_types::{Date, Time, Timestamp},
+};
+
+use crate::{backend::D1Backend, value::D1Value};
+
+use self::chrono::{NaiveDate, NaiveDateTime, NaiveTime};
+
+const DATE_FORMAT: &str = "%F";
+
+const ENCODE_TIME_FORMAT: &str = "%T%.f";
+
+const TIME_FORMATS: [&str; 9] = [
+    // Most likely formats
+    "%T%.f", "%T", // All other valid formats in order of increasing specificity
+    "%R", "%RZ", "%R%:z", "%TZ", "%T%:z", "%T%.fZ", "%T%.f%:z",
+];
+
+const ENCODE_NAIVE_DATETIME_FORMAT: &str = "%F %T%.f";
+
+const NAIVE_DATETIME_FORMATS: [&str; 18] = [
+    // Most likely formats
+    "%F %T%.f",
+    "%F %T%.f%:z",
+    "%F %T",
+    "%F %T%:z",
+    // All other formats in order of increasing specificity
+    "%F %R",
+    "%F %RZ",
+    "%F %R%:z",
+    "%F %TZ",
+    "%F %T%.fZ",
+    "%FT%R",
+    "%FT%RZ",
+    "%FT%R%:z",
+    "%FT%T",
+    "%FT%TZ",
+    "%FT%T%:z",
+    "%FT%T%.f",
+    "%FT%T%.fZ",
+    "%FT%T%.f%:z",
+];
+
+fn parse_julian(julian_days: f64) -> Option<NaiveDateTime> {
+    const EPOCH_IN_JULIAN_DAYS: f64 = 2_440_587.5;
+    const SECONDS_IN_DAY: f64 = 86400.0;
+    let timestamp = (julian_days - EPOCH_IN_JULIAN_DAYS) * SECONDS_IN_DAY;
+    #[allow(clippy::cast_possible_truncation)] // we want to truncate
+    let seconds = timestamp.trunc() as i64;
+    // that's not true, `fract` is always > 0
+    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+    let nanos = (timestamp.fract() * 1E9) as u32;
+    #[allow(deprecated)] // otherwise we would need to bump our minimal chrono version
+    NaiveDateTime::from_timestamp_opt(seconds, nanos)
+}
+
+// Date
+
+impl FromSql<Date, D1Backend> for NaiveDate {
+    fn from_sql(value: D1Value) -> deserialize::Result<Self> {
+        let text = value.read_string();
+        Self::parse_from_str(&text, DATE_FORMAT).map_err(Into::into)
+    }
+}
+
+impl ToSql<Date, D1Backend> for NaiveDate {
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, D1Backend>) -> serialize::Result {
+        out.set_value(self.format(DATE_FORMAT).to_string());
+        Ok(IsNull::No)
+    }
+}
+
+// Time
+
+impl FromSql<Time, D1Backend> for NaiveTime {
+    fn from_sql(value: D1Value) -> deserialize::Result<Self> {
+        let text = value.read_string();
+
+        for format in TIME_FORMATS {
+            if let Ok(time) = Self::parse_from_str(&text, format) {
+                return Ok(time);
+            }
+        }
+
+        Err(format!("Invalid time {text}").into())
+    }
+}
+
+impl ToSql<Time, D1Backend> for NaiveTime {
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, D1Backend>) -> serialize::Result {
+        out.set_value(self.format(ENCODE_TIME_FORMAT).to_string());
+        Ok(IsNull::No)
+    }
+}
+
+// Timestamp
+
+impl FromSql<Timestamp, D1Backend> for NaiveDateTime {
+    fn from_sql(value: D1Value) -> deserialize::Result<Self> {
+        let text = value.read_string();
+
+        for format in NAIVE_DATETIME_FORMATS {
+            if let Ok(dt) = Self::parse_from_str(&text, format) {
+                return Ok(dt);
+            }
+        }
+
+        if let Ok(julian_days) = text.parse::<f64>() {
+            if let Some(timestamp) = parse_julian(julian_days) {
+                return Ok(timestamp);
+            }
+        }
+
+        Err(format!("Invalid datetime {text}").into())
+    }
+}
+
+impl ToSql<Timestamp, D1Backend> for NaiveDateTime {
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, D1Backend>) -> serialize::Result {
+        out.set_value(self.format(ENCODE_NAIVE_DATETIME_FORMAT).to_string());
+        Ok(IsNull::No)
+    }
+}

--- a/src/types/date_and_time/mod.rs
+++ b/src/types/date_and_time/mod.rs
@@ -1,0 +1,75 @@
+#[cfg(feature = "chrono")]
+mod chrono;
+#[cfg(feature = "time")]
+mod time;
+
+use diesel::{
+    deserialize::{self, FromSql},
+    serialize::{self, Output, ToSql},
+    sql_types::{self, HasSqlType},
+};
+
+use crate::{
+    backend::{D1Backend, D1Type},
+    value::D1Value,
+};
+
+// Date
+
+impl HasSqlType<sql_types::Date> for D1Backend {
+    fn metadata(_lookup: &mut ()) -> D1Type {
+        D1Type::Text
+    }
+}
+
+impl FromSql<sql_types::Date, D1Backend> for String {
+    fn from_sql(value: D1Value) -> deserialize::Result<Self> {
+        FromSql::<sql_types::Text, D1Backend>::from_sql(value)
+    }
+}
+
+impl ToSql<sql_types::Date, D1Backend> for String {
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, D1Backend>) -> serialize::Result {
+        ToSql::<sql_types::Text, D1Backend>::to_sql(self, out)
+    }
+}
+
+// Time
+
+impl HasSqlType<sql_types::Time> for D1Backend {
+    fn metadata(_lookup: &mut ()) -> D1Type {
+        D1Type::Text
+    }
+}
+
+impl FromSql<sql_types::Time, D1Backend> for String {
+    fn from_sql(value: D1Value) -> deserialize::Result<Self> {
+        FromSql::<sql_types::Text, D1Backend>::from_sql(value)
+    }
+}
+
+impl ToSql<sql_types::Time, D1Backend> for String {
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, D1Backend>) -> serialize::Result {
+        ToSql::<sql_types::Text, D1Backend>::to_sql(self, out)
+    }
+}
+
+// Timestamp
+
+impl HasSqlType<sql_types::Timestamp> for D1Backend {
+    fn metadata(_lookup: &mut ()) -> D1Type {
+        D1Type::Text
+    }
+}
+
+impl FromSql<sql_types::Timestamp, D1Backend> for String {
+    fn from_sql(value: D1Value) -> deserialize::Result<Self> {
+        FromSql::<sql_types::Text, D1Backend>::from_sql(value)
+    }
+}
+
+impl ToSql<sql_types::Timestamp, D1Backend> for String {
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, D1Backend>) -> serialize::Result {
+        ToSql::<sql_types::Text, D1Backend>::to_sql(self, out)
+    }
+}

--- a/src/types/date_and_time/time.rs
+++ b/src/types/date_and_time/time.rs
@@ -1,0 +1,180 @@
+// Since D1 is a SQlite-compatible DB, we have borrowed time/date/timestamp
+// formats, conversion functions and base impls of the FromSql/ToSql traits
+// from the upstream diesel::sqlite::types::date_and_time::time module
+
+extern crate time;
+
+use diesel::{
+    deserialize::{self, FromSql},
+    serialize::{self, IsNull, Output, ToSql},
+    sql_types::{Date, Time, Timestamp},
+};
+
+use crate::{backend::D1Backend, value::D1Value};
+
+use self::time::{
+    error::ComponentRange, macros::format_description, Date as NaiveDate, OffsetDateTime,
+    PrimitiveDateTime, Time as NaiveTime, UtcOffset,
+};
+
+// the non-deprecated variant does not exist in our minimal supported version
+#[allow(deprecated)]
+use self::time::format_description::FormatItem;
+
+// the non-deprecated variant does not exist in our minimal supported version
+#[allow(deprecated)]
+const DATE_FORMAT: &[FormatItem<'_>] = format_description!("[year]-[month]-[day]");
+
+// the non-deprecated variant does not exist in our minimal supported version
+#[allow(deprecated)]
+const ENCODE_TIME_FORMAT_WHOLE_SECOND: &[FormatItem<'_>] =
+    format_description!("[hour]:[minute]:[second]");
+
+// the non-deprecated variant does not exist in our minimal supported version
+#[allow(deprecated)]
+const ENCODE_TIME_FORMAT_SUBSECOND: &[FormatItem<'_>] =
+    format_description!("[hour]:[minute]:[second].[subsecond]");
+
+// the non-deprecated variant does not exist in our minimal supported version
+#[allow(deprecated)]
+const TIME_FORMATS: [&[FormatItem<'_>]; 9] = [
+    // Most likely formats
+    format_description!("[hour]:[minute]:[second].[subsecond]"),
+    format_description!("[hour]:[minute]:[second]"),
+    // All other valid formats in order of increasing specificity
+    format_description!("[hour]:[minute]"),
+    format_description!("[hour]:[minute]Z"),
+    format_description!("[hour]:[minute][offset_hour sign:mandatory]:[offset_minute]"),
+    format_description!("[hour]:[minute]:[second]Z"),
+    format_description!("[hour]:[minute]:[second][offset_hour sign:mandatory]:[offset_minute]"),
+    format_description!("[hour]:[minute]:[second].[subsecond]Z"),
+    format_description!(
+        "[hour]:[minute]:[second].[subsecond][offset_hour sign:mandatory]:[offset_minute]"
+    ),
+];
+
+// the non-deprecated variant does not exist in our minimal supported version
+#[allow(deprecated)]
+const ENCODE_PRIMITIVE_DATETIME_FORMAT_WHOLE_SECOND: &[FormatItem<'_>] =
+    format_description!("[year]-[month]-[day] [hour]:[minute]:[second]");
+
+// the non-deprecated variant does not exist in our minimal supported version
+#[allow(deprecated)]
+const ENCODE_PRIMITIVE_DATETIME_FORMAT_SUBSECOND: &[FormatItem<'_>] =
+    format_description!("[year]-[month]-[day] [hour]:[minute]:[second].[subsecond]");
+
+// the non-deprecated variant does not exist in our minimal supported version
+#[allow(deprecated)]
+const PRIMITIVE_DATETIME_FORMATS: [&[FormatItem<'_>]; 18] = [
+    // Most likely formats
+    format_description!("[year]-[month]-[day] [hour]:[minute]:[second].[subsecond]"),
+    format_description!("[year]-[month]-[day] [hour]:[minute]:[second].[subsecond][offset_hour sign:mandatory]:[offset_minute]"),
+    format_description!("[year]-[month]-[day] [hour]:[minute]:[second]"),
+    format_description!("[year]-[month]-[day] [hour]:[minute]:[second][offset_hour sign:mandatory]:[offset_minute]"),
+    // All other formats in order of increasing specificity
+    format_description!("[year]-[month]-[day] [hour]:[minute]"),
+    format_description!("[year]-[month]-[day] [hour]:[minute]Z"),
+    format_description!("[year]-[month]-[day] [hour]:[minute][offset_hour sign:mandatory]:[offset_minute]"),
+    format_description!("[year]-[month]-[day] [hour]:[minute]:[second]Z"),
+    format_description!("[year]-[month]-[day] [hour]:[minute]:[second].[subsecond]Z"),
+    format_description!("[year]-[month]-[day]T[hour]:[minute]"),
+    format_description!("[year]-[month]-[day]T[hour]:[minute]Z"),
+    format_description!("[year]-[month]-[day]T[hour]:[minute][offset_hour sign:mandatory]:[offset_minute]"),
+    format_description!("[year]-[month]-[day]T[hour]:[minute]:[second]"),
+    format_description!("[year]-[month]-[day]T[hour]:[minute]:[second]Z"),
+    format_description!("[year]-[month]-[day]T[hour]:[minute]:[second][offset_hour sign:mandatory]:[offset_minute]"),
+    format_description!("[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond]"),
+    format_description!("[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond]Z"),
+    format_description!("[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond][offset_hour sign:mandatory]:[offset_minute]"),
+];
+
+fn naive_utc(dt: OffsetDateTime) -> PrimitiveDateTime {
+    let dt = dt.to_offset(UtcOffset::UTC);
+    PrimitiveDateTime::new(dt.date(), dt.time())
+}
+
+fn parse_julian(julian_days: f64) -> Result<PrimitiveDateTime, ComponentRange> {
+    const EPOCH_IN_JULIAN_DAYS: f64 = 2_440_587.5;
+    const SECONDS_IN_DAY: f64 = 86400.0;
+    let timestamp = (julian_days - EPOCH_IN_JULIAN_DAYS) * SECONDS_IN_DAY;
+    #[allow(clippy::cast_possible_truncation)] // we multiply by 1E9 to prevent that
+    OffsetDateTime::from_unix_timestamp_nanos((timestamp * 1E9) as i128).map(naive_utc)
+}
+
+// Date
+
+impl FromSql<Date, D1Backend> for NaiveDate {
+    fn from_sql(value: D1Value) -> deserialize::Result<Self> {
+        let text = value.read_string();
+        Self::parse(&text, DATE_FORMAT).map_err(Into::into)
+    }
+}
+
+impl ToSql<Date, D1Backend> for NaiveDate {
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, D1Backend>) -> serialize::Result {
+        out.set_value(self.format(DATE_FORMAT).map_err(|err| err.to_string())?);
+        Ok(IsNull::No)
+    }
+}
+
+// Time
+
+impl FromSql<Time, D1Backend> for NaiveTime {
+    fn from_sql(value: D1Value) -> deserialize::Result<Self> {
+        let text = value.read_string();
+
+        for format in TIME_FORMATS {
+            if let Ok(time) = Self::parse(&text, format) {
+                return Ok(time);
+            }
+        }
+
+        Err(format!("Invalid time {text}").into())
+    }
+}
+
+impl ToSql<Time, D1Backend> for NaiveTime {
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, D1Backend>) -> serialize::Result {
+        let format = if self.microsecond() == 0 {
+            ENCODE_TIME_FORMAT_WHOLE_SECOND
+        } else {
+            ENCODE_TIME_FORMAT_SUBSECOND
+        };
+        out.set_value(self.format(format).map_err(|err| err.to_string())?);
+        Ok(IsNull::No)
+    }
+}
+
+// Timestamp
+
+impl FromSql<Timestamp, D1Backend> for PrimitiveDateTime {
+    fn from_sql(value: D1Value) -> deserialize::Result<Self> {
+        let text = value.read_string();
+
+        for format in PRIMITIVE_DATETIME_FORMATS {
+            if let Ok(dt) = Self::parse(&text, format) {
+                return Ok(dt);
+            }
+        }
+
+        if let Ok(julian_days) = text.parse::<f64>() {
+            if let Ok(timestamp) = parse_julian(julian_days) {
+                return Ok(timestamp);
+            }
+        }
+
+        Err(format!("Invalid datetime {text}").into())
+    }
+}
+
+impl ToSql<Timestamp, D1Backend> for PrimitiveDateTime {
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, D1Backend>) -> serialize::Result {
+        let format = if self.nanosecond() == 0 {
+            ENCODE_PRIMITIVE_DATETIME_FORMAT_WHOLE_SECOND
+        } else {
+            ENCODE_PRIMITIVE_DATETIME_FORMAT_SUBSECOND
+        };
+        out.set_value(self.format(format).map_err(|err| err.to_string())?);
+        Ok(IsNull::No)
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,3 +1,5 @@
+mod date_and_time;
+
 use diesel::{
     deserialize::{self, FromSql},
     serialize::{self, IsNull, Output, ToSql},
@@ -22,7 +24,7 @@ impl FromSql<sql_types::Bool, D1Backend> for bool {
         let bool_number = value.read_number();
         if !(bool_number == 0.0 || bool_number == 1.0) {
             panic!("this shouldn't happen bool is not a bool");
-        } 
+        }
         Ok(bool_number != 0.0)
     }
 }
@@ -199,55 +201,5 @@ impl ToSql<sql_types::Binary, D1Backend> for *const [u8] {
         let value = unsafe { js_sys::Uint8Array::new(&Uint8Array::view(self.as_ref().unwrap())) };
         out.set_value(value);
         Ok(IsNull::No)
-    }
-}
-
-// ------ Time related (simplified to only text)
-
-impl HasSqlType<sql_types::Date> for D1Backend {
-    fn metadata(_lookup: &mut ()) -> D1Type {
-        D1Type::Text
-    }
-}
-
-impl HasSqlType<sql_types::Time> for D1Backend {
-    fn metadata(_lookup: &mut ()) -> D1Type {
-        D1Type::Text
-    }
-}
-
-impl HasSqlType<sql_types::Timestamp> for D1Backend {
-    fn metadata(_lookup: &mut ()) -> D1Type {
-        D1Type::Text
-    }
-}
-
-impl FromSql<sql_types::Date, D1Backend> for String {
-    fn from_sql(value: D1Value) -> deserialize::Result<Self> {
-        FromSql::<sql_types::Text, D1Backend>::from_sql(value)
-    }
-}
-
-impl ToSql<sql_types::Date, D1Backend> for String {
-    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, D1Backend>) -> serialize::Result {
-        ToSql::<sql_types::Text, D1Backend>::to_sql(self, out)
-    }
-}
-
-impl FromSql<sql_types::Time, D1Backend> for String {
-    fn from_sql(value: D1Value) -> deserialize::Result<Self> {
-        FromSql::<sql_types::Text, D1Backend>::from_sql(value)
-    }
-}
-
-impl FromSql<sql_types::Timestamp, D1Backend> for String {
-    fn from_sql(value: D1Value) -> deserialize::Result<Self> {
-        FromSql::<sql_types::Text, D1Backend>::from_sql(value)
-    }
-}
-
-impl ToSql<sql_types::Timestamp, D1Backend> for String {
-    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, D1Backend>) -> serialize::Result {
-        ToSql::<sql_types::Text, D1Backend>::to_sql(self, out)
     }
 }


### PR DESCRIPTION
This change allows to use date and time types from `chrono` and `time` libraries directly on the model fields, as it implemented in upstream library itself: 

```rs
use chrono::NaiveDateTime;
use diesel::prelude::*;

#[derive(Queryable, Selectable)]
#[diesel(table_name = crate::schema::posts)]
pub struct Post {
    pub id: i32,
    pub title: String,
    pub body: String,
    pub published_at: NaiveDateTime,
}
``` 