### PR TITLE
explicitly provide type argument to avoid breakage in future Rust versions

### DIFF
--- a/src/bind_collector.rs
+++ b/src/bind_collector.rs
@@ -37,7 +37,7 @@ impl<'bind> BindCollector<'bind, D1Backend> for D1BindCollector {
             JsValue::null()
         };
 
-        let metadata = D1Backend::metadata(metadata_lookup);
+        let metadata = <D1Backend as HasSqlType<T>>::metadata(metadata_lookup);
         self.binds.push((bind, metadata));
         Ok(())
     }


### PR DESCRIPTION
`D1Backend` has multiple where-bounds for `HasSqlType` due to the super-traits of `diesel::backend::Backend`: `HasSqlType<SmallInt>`, `HasSqlType<Integer>`, and others. It also has one where-bound which references a generic parameter, i.e. which is *non-global*: `HasSqlType<T>`.

The compiler previously preferred such *non-global* where-bounds over *global*[^1] where-bounds in some cases, guiding type inference. This behavior was quite subtle and inconsistent, so we've reworked the implementation in https://github.com/rust-lang/rust/pull/132325.

Because of this, we no longer infer the type argument of `<D1Backend as HasSqlType<_>>::metadata` to `T` as using `SmallInt` or `Integer` is just as valid and would also allow this code to compile. The change in inference behavior will likely be stable in version 1.85. This PR modifies your code to make the used type explicit, allowing your crate to compile in future Rust versions.

[^1]: pretty much: a where-bound which does not mention any generic parameters